### PR TITLE
Add production configuration

### DIFF
--- a/contracts/script/.env.sample
+++ b/contracts/script/.env.sample
@@ -4,3 +4,5 @@ RPC_URL="https://auto-evm.chronos.autonomys.xyz/ws"
 PRIVATE_KEY=""
 # Contract address used when granting and revoking minter role
 CONTRACT_ADDRESS="0xCBD609f1CE467e149359475aa2f28daC6B75170d"
+# Verification explorer URL
+VERIFIER_URL="https://explorer.auto-evm.chronos.autonomys.xyz/api"

--- a/contracts/script/verify.sh
+++ b/contracts/script/verify.sh
@@ -9,7 +9,7 @@ fi
 forge verify-contract  \
     --rpc-url $RPC_URL  \
     --verifier blockscout  \
-    --verifier-url https://explorer.auto-evm.chronos.autonomys.xyz/api \
+    --verifier-url $VERIFIER_URL \
     --evm-version london \
     --chain $CHAIN_ID \
     --compiler-version 0.8.30  \

--- a/subgraph/subgraph.production.yaml
+++ b/subgraph/subgraph.production.yaml
@@ -4,11 +4,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: EternalMintNfts
-    network: autonomys-mainnet
+    network: autonomys
     source:
-      address: "0x2601FB64e5cA137f273Fa64c28056a040d132A1b"
+      address: "0x6C3bbcA5164Dde0688E75b6b389cBF5986c7E221"
       abi: EternalMintNfts
-      startBlock: 282110
+      startBlock: 733999
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/web/src/config/app.ts
+++ b/web/src/config/app.ts
@@ -121,8 +121,8 @@ export const CONTRACT_DEPLOYMENTS = {
   production: {
     evmNetwork: 'mainnet' as NetworkName, // Will change to 'mainnet' when ready
     storageNetwork: 'mainnet' as StorageNetworkName, // Could use mainnet storage even with chronos EVM
-    contractAddress: '0x8A7325f9eA80D65c8f69F3797F345Cc831EC01f4', // Will be different for production
-    subgraphUrl: 'https://api.studio.thegraph.com/query/114204/eternalmint-pro/v0.0.2', // Different subgraph for production
+    contractAddress: '0x6C3bbcA5164Dde0688E75b6b389cBF5986c7E221', // Will be different for production
+    subgraphUrl: 'https://api.studio.thegraph.com/query/114204/eternalmint-pro/v0.0.6', // Different subgraph for production
     version: '1.0.0',
     deployedAt: '2025-06-25', // Update with actual deployment date
   },


### PR DESCRIPTION
Add production (mainnet) contract and subgraph details to config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update production contract address and subgraph, adjust subgraph network/start block, and externalize the verifier URL for contract verification.
> 
> - **Config/Infra**:
>   - **Web app (`web/src/config/app.ts`)**: Update production `contractAddress` to `0x6C3bbcA5164Dde0688E75b6b389cBF5986c7E221` and `subgraphUrl` to `.../eternalmint-pro/v0.0.6`.
>   - **Subgraph (`subgraph/subgraph.production.yaml`)**: Change `network` to `autonomys`, update `source.address` to `0x6C3bbcA5164Dde0688E75b6b389cBF5986c7E221`, and `startBlock` to `733999`.
> - **Scripts**:
>   - **Env (`contracts/script/.env.sample`)**: Add `VERIFIER_URL`.
>   - **Verify script (`contracts/script/verify.sh`)**: Use `$VERIFIER_URL` instead of hardcoded Blockscout URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdfd8e353671694819f37a375e44912bca6e5c9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->